### PR TITLE
Redefine zero and one elements for variables

### DIFF
--- a/src/SemiringAlgebra.jl
+++ b/src/SemiringAlgebra.jl
@@ -13,8 +13,10 @@ end
 *(a::MPNumber, b::MPNumber) = MPNumber(a.val+b.val)
 
 Base.show(io::IO, k::MPNumber) = print(io, k.val)
-Base.zero(::Type{MPNumber{T}}) where{T} = MPNumber(typemin(T))
-Base.one(::Type{MPNumber{T}}) where{T}  = MPNumber(zero(T))
+Base.zero(::MPNumber{T}) where T = MPNumber(typemin(T))
+Base.one(::MPNumber{T}) where T = MPNumber(zero(T))
+Base.zero(::Type{MPNumber{T}}) where T = MPNumber(typemin(T))
+Base.one(::Type{MPNumber{T}}) where T = MPNumber(zero(T))
 Base.promote_rule(::Type{MPNumber}, ::Type{Number}) = MPNumber
 
 mparray(A::Array) = map(MPNumber, A)


### PR DESCRIPTION
Previously they were only redefined for types. This caused problems when I tried to used a `min-plus` algebra (and not a `max-plus` one). I found the solution in a [comment on Stack Overflow](https://stackoverflow.com/questions/50106950/semiring-matrix-vector-product-in-julia-not-working#comment87233338_50107428), which stated that

> In Julia you want both `zero(MPNumber{Int64})` and `zero(MPNumber(1))` to produce zero of your type.

I am not an expert in Julia, so any feedback is welcome.